### PR TITLE
[Update] SDK

### DIFF
--- a/PowerSyncExample.xcodeproj/project.pbxproj
+++ b/PowerSyncExample.xcodeproj/project.pbxproj
@@ -502,7 +502,7 @@
 			repositoryURL = "https://github.com/powersync-ja/powersync-kotlin.git";
 			requirement = {
 				kind = exactVersion;
-				version = "0.0.1-ALPHA4.0";
+				version = "0.0.1-ALPHA5.0";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/PowerSyncExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PowerSyncExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/powersync-ja/powersync-kotlin.git",
       "state" : {
-        "revision" : "f124bedb181b6dc4f76103a9e2bd5c4d248b506a",
-        "version" : "0.0.1-ALPHA4.0"
+        "revision" : "00d0bfe9800dc39d8cd4dcade5611b744216b842",
+        "version" : "0.0.1-ALPHA5.0"
       }
     },
     {


### PR DESCRIPTION
This updates the PowerSync Swift SDK to `v0.0.1-ALPHA5.0`. This reflects changes from https://github.com/powersync-ja/powersync-kotlin/pull/8.

Upstream changes now reflect on the device.

https://github.com/powersync-ja/powersync-kotlin-swift-demo/assets/51082125/c3e5ce67-1069-43f0-8fc7-29fe92fe8eeb

