### PR TITLE
chore: update package imports and clean up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,63 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+.DS_Store
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
+#
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+# .swiftpm
+
+.build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# Pods/
+#
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build/
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output

--- a/PowerSyncExample.xcodeproj/project.pbxproj
+++ b/PowerSyncExample.xcodeproj/project.pbxproj
@@ -32,7 +32,7 @@
 		6ABD78802B9F2F1300558A41 /* AddTodoListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ABD787F2B9F2F1300558A41 /* AddTodoListView.swift */; };
 		6AC6A3062BA18313006CE8D9 /* powersync-sqlite-core.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AC6A3052BA18313006CE8D9 /* powersync-sqlite-core.xcframework */; };
 		6AC6A3072BA18313006CE8D9 /* powersync-sqlite-core.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6AC6A3052BA18313006CE8D9 /* powersync-sqlite-core.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		6AC6A3112BA19942006CE8D9 /* powersyncswift in Frameworks */ = {isa = PBXBuildFile; productRef = 6AC6A3102BA19942006CE8D9 /* powersyncswift */; };
+		B67712722C240A1300BFA931 /* PowerSync in Frameworks */ = {isa = PBXBuildFile; productRef = B67712712C240A1300BFA931 /* PowerSync */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -68,6 +68,30 @@
 		6ABD787D2B9F2E8700558A41 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		6ABD787F2B9F2F1300558A41 /* AddTodoListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTodoListView.swift; sourceTree = "<group>"; };
 		6AC6A3052BA18313006CE8D9 /* powersync-sqlite-core.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = "powersync-sqlite-core.xcframework"; sourceTree = "<group>"; };
+		B67712702C2404E300BFA931 /* powersync-kotlin */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "powersync-kotlin"; path = "../powersync-kotlin"; sourceTree = "<group>"; };
+		B6F4210E2BC42F450005D0D0 /* cstubs.bc */ = {isa = PBXFileReference; lastKnownFileType = file; path = cstubs.bc; sourceTree = "<group>"; };
+		B6F421102BC42F450005D0D0 /* manifest.properties */ = {isa = PBXFileReference; lastKnownFileType = text; path = manifest.properties; sourceTree = "<group>"; };
+		B6F421122BC42F450005D0D0 /* cstubs.bc */ = {isa = PBXFileReference; lastKnownFileType = file; path = cstubs.bc; sourceTree = "<group>"; };
+		B6F421142BC42F450005D0D0 /* manifest.properties */ = {isa = PBXFileReference; lastKnownFileType = text; path = manifest.properties; sourceTree = "<group>"; };
+		B6F421162BC42F450005D0D0 /* core-cinterop-powersync-sqlite-core.klib */ = {isa = PBXFileReference; lastKnownFileType = file; path = "core-cinterop-powersync-sqlite-core.klib"; sourceTree = "<group>"; };
+		B6F421172BC42F450005D0D0 /* core-cinterop-sqlite.klib */ = {isa = PBXFileReference; lastKnownFileType = file; path = "core-cinterop-sqlite.klib"; sourceTree = "<group>"; };
+		B6F421192BC42F450005D0D0 /* core.klib */ = {isa = PBXFileReference; lastKnownFileType = file; path = core.klib; sourceTree = "<group>"; };
+		B6F4211D2BC42F450005D0D0 /* cstubs.bc */ = {isa = PBXFileReference; lastKnownFileType = file; path = cstubs.bc; sourceTree = "<group>"; };
+		B6F4211F2BC42F450005D0D0 /* manifest.properties */ = {isa = PBXFileReference; lastKnownFileType = text; path = manifest.properties; sourceTree = "<group>"; };
+		B6F421212BC42F450005D0D0 /* cstubs.bc */ = {isa = PBXFileReference; lastKnownFileType = file; path = cstubs.bc; sourceTree = "<group>"; };
+		B6F421232BC42F450005D0D0 /* manifest.properties */ = {isa = PBXFileReference; lastKnownFileType = text; path = manifest.properties; sourceTree = "<group>"; };
+		B6F421252BC42F450005D0D0 /* core-cinterop-powersync-sqlite-core.klib */ = {isa = PBXFileReference; lastKnownFileType = file; path = "core-cinterop-powersync-sqlite-core.klib"; sourceTree = "<group>"; };
+		B6F421262BC42F450005D0D0 /* core-cinterop-sqlite.klib */ = {isa = PBXFileReference; lastKnownFileType = file; path = "core-cinterop-sqlite.klib"; sourceTree = "<group>"; };
+		B6F421282BC42F450005D0D0 /* core.klib */ = {isa = PBXFileReference; lastKnownFileType = file; path = core.klib; sourceTree = "<group>"; };
+		B6F4212C2BC42F450005D0D0 /* cstubs.bc */ = {isa = PBXFileReference; lastKnownFileType = file; path = cstubs.bc; sourceTree = "<group>"; };
+		B6F4212E2BC42F450005D0D0 /* manifest.properties */ = {isa = PBXFileReference; lastKnownFileType = text; path = manifest.properties; sourceTree = "<group>"; };
+		B6F421302BC42F450005D0D0 /* cstubs.bc */ = {isa = PBXFileReference; lastKnownFileType = file; path = cstubs.bc; sourceTree = "<group>"; };
+		B6F421322BC42F450005D0D0 /* manifest.properties */ = {isa = PBXFileReference; lastKnownFileType = text; path = manifest.properties; sourceTree = "<group>"; };
+		B6F421342BC42F450005D0D0 /* core-cinterop-powersync-sqlite-core.klib */ = {isa = PBXFileReference; lastKnownFileType = file; path = "core-cinterop-powersync-sqlite-core.klib"; sourceTree = "<group>"; };
+		B6F421352BC42F450005D0D0 /* core-cinterop-sqlite.klib */ = {isa = PBXFileReference; lastKnownFileType = file; path = "core-cinterop-sqlite.klib"; sourceTree = "<group>"; };
+		B6F421372BC42F450005D0D0 /* core.klib */ = {isa = PBXFileReference; lastKnownFileType = file; path = core.klib; sourceTree = "<group>"; };
+		B6F4213D2BC42F5B0005D0D0 /* sqlite3.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = sqlite3.c; path = "../powersync-kotlin/core/build/interop/sqlite/sqlite3.c"; sourceTree = "<group>"; };
+		B6F421402BC430B60005D0D0 /* sqlite3.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = sqlite3.h; path = "../powersync-kotlin/core/build/interop/sqlite/sqlite3.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -82,8 +106,8 @@
 				6A9669002B9EE4FE00B05DCF /* PostgREST in Frameworks */,
 				6ABD78762B9F2CFB00558A41 /* SwiftUINavigationCore in Frameworks */,
 				6AC6A3062BA18313006CE8D9 /* powersync-sqlite-core.xcframework in Frameworks */,
+				B67712722C240A1300BFA931 /* PowerSync in Frameworks */,
 				6A9668FE2B9EE4FE00B05DCF /* Auth in Frameworks */,
-				6AC6A3112BA19942006CE8D9 /* powersyncswift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -93,6 +117,7 @@
 		6A73157B2B9854220004CB17 = {
 			isa = PBXGroup;
 			children = (
+				B67712702C2404E300BFA931 /* powersync-kotlin */,
 				6A7315862B9854220004CB17 /* PowerSyncExample */,
 				6A7315852B9854220004CB17 /* Products */,
 				6A7315B52B9857AD0004CB17 /* Frameworks */,
@@ -140,6 +165,9 @@
 		6A7315B52B9857AD0004CB17 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				B6F421402BC430B60005D0D0 /* sqlite3.h */,
+				B6F4213D2BC42F5B0005D0D0 /* sqlite3.c */,
+				B6F4213C2BC42F450005D0D0 /* classes */,
 				6AC6A3052BA18313006CE8D9 /* powersync-sqlite-core.xcframework */,
 			);
 			name = Frameworks;
@@ -152,6 +180,235 @@
 				6A4AD3842B9EE763005CBFD4 /* SupabaseConnector.swift */,
 			);
 			path = Supabase;
+			sourceTree = "<group>";
+		};
+		B6F4210F2BC42F450005D0D0 /* natives */ = {
+			isa = PBXGroup;
+			children = (
+				B6F4210E2BC42F450005D0D0 /* cstubs.bc */,
+			);
+			path = natives;
+			sourceTree = "<group>";
+		};
+		B6F421112BC42F450005D0D0 /* core-cinterop-powersync-sqlite-core.klib-build */ = {
+			isa = PBXGroup;
+			children = (
+				B6F4210F2BC42F450005D0D0 /* natives */,
+				B6F421102BC42F450005D0D0 /* manifest.properties */,
+			);
+			path = "core-cinterop-powersync-sqlite-core.klib-build";
+			sourceTree = "<group>";
+		};
+		B6F421132BC42F450005D0D0 /* natives */ = {
+			isa = PBXGroup;
+			children = (
+				B6F421122BC42F450005D0D0 /* cstubs.bc */,
+			);
+			path = natives;
+			sourceTree = "<group>";
+		};
+		B6F421152BC42F450005D0D0 /* core-cinterop-sqlite.klib-build */ = {
+			isa = PBXGroup;
+			children = (
+				B6F421132BC42F450005D0D0 /* natives */,
+				B6F421142BC42F450005D0D0 /* manifest.properties */,
+			);
+			path = "core-cinterop-sqlite.klib-build";
+			sourceTree = "<group>";
+		};
+		B6F421182BC42F450005D0D0 /* cinterop */ = {
+			isa = PBXGroup;
+			children = (
+				B6F421112BC42F450005D0D0 /* core-cinterop-powersync-sqlite-core.klib-build */,
+				B6F421152BC42F450005D0D0 /* core-cinterop-sqlite.klib-build */,
+				B6F421162BC42F450005D0D0 /* core-cinterop-powersync-sqlite-core.klib */,
+				B6F421172BC42F450005D0D0 /* core-cinterop-sqlite.klib */,
+			);
+			path = cinterop;
+			sourceTree = "<group>";
+		};
+		B6F4211A2BC42F450005D0D0 /* klib */ = {
+			isa = PBXGroup;
+			children = (
+				B6F421192BC42F450005D0D0 /* core.klib */,
+			);
+			path = klib;
+			sourceTree = "<group>";
+		};
+		B6F4211B2BC42F450005D0D0 /* main */ = {
+			isa = PBXGroup;
+			children = (
+				B6F421182BC42F450005D0D0 /* cinterop */,
+				B6F4211A2BC42F450005D0D0 /* klib */,
+			);
+			path = main;
+			sourceTree = "<group>";
+		};
+		B6F4211C2BC42F450005D0D0 /* iosArm64 */ = {
+			isa = PBXGroup;
+			children = (
+				B6F4211B2BC42F450005D0D0 /* main */,
+			);
+			path = iosArm64;
+			sourceTree = "<group>";
+		};
+		B6F4211E2BC42F450005D0D0 /* natives */ = {
+			isa = PBXGroup;
+			children = (
+				B6F4211D2BC42F450005D0D0 /* cstubs.bc */,
+			);
+			path = natives;
+			sourceTree = "<group>";
+		};
+		B6F421202BC42F450005D0D0 /* core-cinterop-powersync-sqlite-core.klib-build */ = {
+			isa = PBXGroup;
+			children = (
+				B6F4211E2BC42F450005D0D0 /* natives */,
+				B6F4211F2BC42F450005D0D0 /* manifest.properties */,
+			);
+			path = "core-cinterop-powersync-sqlite-core.klib-build";
+			sourceTree = "<group>";
+		};
+		B6F421222BC42F450005D0D0 /* natives */ = {
+			isa = PBXGroup;
+			children = (
+				B6F421212BC42F450005D0D0 /* cstubs.bc */,
+			);
+			path = natives;
+			sourceTree = "<group>";
+		};
+		B6F421242BC42F450005D0D0 /* core-cinterop-sqlite.klib-build */ = {
+			isa = PBXGroup;
+			children = (
+				B6F421222BC42F450005D0D0 /* natives */,
+				B6F421232BC42F450005D0D0 /* manifest.properties */,
+			);
+			path = "core-cinterop-sqlite.klib-build";
+			sourceTree = "<group>";
+		};
+		B6F421272BC42F450005D0D0 /* cinterop */ = {
+			isa = PBXGroup;
+			children = (
+				B6F421202BC42F450005D0D0 /* core-cinterop-powersync-sqlite-core.klib-build */,
+				B6F421242BC42F450005D0D0 /* core-cinterop-sqlite.klib-build */,
+				B6F421252BC42F450005D0D0 /* core-cinterop-powersync-sqlite-core.klib */,
+				B6F421262BC42F450005D0D0 /* core-cinterop-sqlite.klib */,
+			);
+			path = cinterop;
+			sourceTree = "<group>";
+		};
+		B6F421292BC42F450005D0D0 /* klib */ = {
+			isa = PBXGroup;
+			children = (
+				B6F421282BC42F450005D0D0 /* core.klib */,
+			);
+			path = klib;
+			sourceTree = "<group>";
+		};
+		B6F4212A2BC42F450005D0D0 /* main */ = {
+			isa = PBXGroup;
+			children = (
+				B6F421272BC42F450005D0D0 /* cinterop */,
+				B6F421292BC42F450005D0D0 /* klib */,
+			);
+			path = main;
+			sourceTree = "<group>";
+		};
+		B6F4212B2BC42F450005D0D0 /* iosSimulatorArm64 */ = {
+			isa = PBXGroup;
+			children = (
+				B6F4212A2BC42F450005D0D0 /* main */,
+			);
+			path = iosSimulatorArm64;
+			sourceTree = "<group>";
+		};
+		B6F4212D2BC42F450005D0D0 /* natives */ = {
+			isa = PBXGroup;
+			children = (
+				B6F4212C2BC42F450005D0D0 /* cstubs.bc */,
+			);
+			path = natives;
+			sourceTree = "<group>";
+		};
+		B6F4212F2BC42F450005D0D0 /* core-cinterop-powersync-sqlite-core.klib-build */ = {
+			isa = PBXGroup;
+			children = (
+				B6F4212D2BC42F450005D0D0 /* natives */,
+				B6F4212E2BC42F450005D0D0 /* manifest.properties */,
+			);
+			path = "core-cinterop-powersync-sqlite-core.klib-build";
+			sourceTree = "<group>";
+		};
+		B6F421312BC42F450005D0D0 /* natives */ = {
+			isa = PBXGroup;
+			children = (
+				B6F421302BC42F450005D0D0 /* cstubs.bc */,
+			);
+			path = natives;
+			sourceTree = "<group>";
+		};
+		B6F421332BC42F450005D0D0 /* core-cinterop-sqlite.klib-build */ = {
+			isa = PBXGroup;
+			children = (
+				B6F421312BC42F450005D0D0 /* natives */,
+				B6F421322BC42F450005D0D0 /* manifest.properties */,
+			);
+			path = "core-cinterop-sqlite.klib-build";
+			sourceTree = "<group>";
+		};
+		B6F421362BC42F450005D0D0 /* cinterop */ = {
+			isa = PBXGroup;
+			children = (
+				B6F4212F2BC42F450005D0D0 /* core-cinterop-powersync-sqlite-core.klib-build */,
+				B6F421332BC42F450005D0D0 /* core-cinterop-sqlite.klib-build */,
+				B6F421342BC42F450005D0D0 /* core-cinterop-powersync-sqlite-core.klib */,
+				B6F421352BC42F450005D0D0 /* core-cinterop-sqlite.klib */,
+			);
+			path = cinterop;
+			sourceTree = "<group>";
+		};
+		B6F421382BC42F450005D0D0 /* klib */ = {
+			isa = PBXGroup;
+			children = (
+				B6F421372BC42F450005D0D0 /* core.klib */,
+			);
+			path = klib;
+			sourceTree = "<group>";
+		};
+		B6F421392BC42F450005D0D0 /* main */ = {
+			isa = PBXGroup;
+			children = (
+				B6F421362BC42F450005D0D0 /* cinterop */,
+				B6F421382BC42F450005D0D0 /* klib */,
+			);
+			path = main;
+			sourceTree = "<group>";
+		};
+		B6F4213A2BC42F450005D0D0 /* iosX64 */ = {
+			isa = PBXGroup;
+			children = (
+				B6F421392BC42F450005D0D0 /* main */,
+			);
+			path = iosX64;
+			sourceTree = "<group>";
+		};
+		B6F4213B2BC42F450005D0D0 /* kotlin */ = {
+			isa = PBXGroup;
+			children = (
+				B6F4211C2BC42F450005D0D0 /* iosArm64 */,
+				B6F4212B2BC42F450005D0D0 /* iosSimulatorArm64 */,
+				B6F4213A2BC42F450005D0D0 /* iosX64 */,
+			);
+			path = kotlin;
+			sourceTree = "<group>";
+		};
+		B6F4213C2BC42F450005D0D0 /* classes */ = {
+			isa = PBXGroup;
+			children = (
+				B6F4213B2BC42F450005D0D0 /* kotlin */,
+			);
+			name = classes;
+			path = "../powersync-kotlin/core/build/classes";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -179,7 +436,7 @@
 				6ABD78702B9F2CD400558A41 /* IdentifiedCollections */,
 				6ABD78732B9F2CFB00558A41 /* SwiftUINavigation */,
 				6ABD78752B9F2CFB00558A41 /* SwiftUINavigationCore */,
-				6AC6A3102BA19942006CE8D9 /* powersyncswift */,
+				B67712712C240A1300BFA931 /* PowerSync */,
 			);
 			productName = PowerSyncExample;
 			productReference = 6A7315842B9854220004CB17 /* PowerSyncExample.app */;
@@ -319,6 +576,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = "-lsqlite3";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -375,6 +633,7 @@
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
+				OTHER_LDFLAGS = "-lsqlite3";
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				VALIDATE_PRODUCT = YES;
@@ -384,12 +643,13 @@
 		6A7315932B9854240004CB17 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLY_RULES_IN_COPY_HEADERS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"PowerSyncExample/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 6WA62GTJNA;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -402,7 +662,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_LDFLAGS = "-lsqlite3";
+				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.powersync.PowerSyncExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -414,12 +674,13 @@
 		6A7315942B9854240004CB17 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLY_RULES_IN_COPY_HEADERS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"PowerSyncExample/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 6WA62GTJNA;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -432,7 +693,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_LDFLAGS = "-lsqlite3";
+				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.powersync.PowerSyncExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -502,7 +763,7 @@
 			repositoryURL = "https://github.com/powersync-ja/powersync-kotlin.git";
 			requirement = {
 				kind = exactVersion;
-				version = "0.0.1-ALPHA5.0";
+				version = "0.0.1-ALPHA13.0";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -543,10 +804,9 @@
 			package = 6ABD78722B9F2CFB00558A41 /* XCRemoteSwiftPackageReference "swiftui-navigation" */;
 			productName = SwiftUINavigationCore;
 		};
-		6AC6A3102BA19942006CE8D9 /* powersyncswift */ = {
+		B67712712C240A1300BFA931 /* PowerSync */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 6AC6A30F2BA19942006CE8D9 /* XCRemoteSwiftPackageReference "powersync-kotlin" */;
-			productName = powersyncswift;
+			productName = PowerSync;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/PowerSyncExample.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/PowerSyncExample.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/PowerSyncExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PowerSyncExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,114 +1,97 @@
 {
-  "originHash" : "cad047154dd0751ae691260d689c3340e8f7d9d266a58195de31a63e825b9f12",
-  "pins" : [
-    {
-      "identity" : "keychainaccess",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kishikawakatsumi/KeychainAccess",
-      "state" : {
-        "revision" : "84e546727d66f1adc5439debad16270d0fdd04e7",
-        "version" : "4.2.2"
+  "object": {
+    "pins": [
+      {
+        "package": "Supabase",
+        "repositoryURL": "https://github.com/supabase-community/supabase-swift.git",
+        "state": {
+          "branch": null,
+          "revision": "a50157fb848e1748aaf432ed36f71604cfa96d29",
+          "version": "2.13.3"
+        }
+      },
+      {
+        "package": "swift-case-paths",
+        "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
+        "state": {
+          "branch": null,
+          "revision": "b871e5ed11a23e52c2896a92ce2c829982ff8619",
+          "version": "1.4.2"
+        }
+      },
+      {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections.git",
+        "state": {
+          "branch": null,
+          "revision": "ee97538f5b81ae89698fd95938896dec5217b148",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "package": "swift-concurrency-extras",
+        "repositoryURL": "https://github.com/pointfreeco/swift-concurrency-extras",
+        "state": {
+          "branch": null,
+          "revision": "bb5059bde9022d69ac516803f4f227d8ac967f71",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "package": "swift-crypto",
+        "repositoryURL": "https://github.com/apple/swift-crypto.git",
+        "state": {
+          "branch": null,
+          "revision": "bc1c29221f6dfeb0ebbfbc98eb95cd3d4967868e",
+          "version": "3.4.0"
+        }
+      },
+      {
+        "package": "swift-custom-dump",
+        "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
+        "state": {
+          "branch": null,
+          "revision": "f01efb26f3a192a0e88dcdb7c3c391ec2fc25d9c",
+          "version": "1.3.0"
+        }
+      },
+      {
+        "package": "swift-identified-collections",
+        "repositoryURL": "https://github.com/pointfreeco/swift-identified-collections.git",
+        "state": {
+          "branch": null,
+          "revision": "2f5ab6e091dd032b63dacbda052405756010dc3b",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "package": "swift-syntax",
+        "repositoryURL": "https://github.com/apple/swift-syntax",
+        "state": {
+          "branch": null,
+          "revision": "303e5c5c36d6a558407d364878df131c3546fad8",
+          "version": "510.0.2"
+        }
+      },
+      {
+        "package": "swiftui-navigation",
+        "repositoryURL": "https://github.com/pointfreeco/swiftui-navigation.git",
+        "state": {
+          "branch": null,
+          "revision": "b7c9a79f6f6b1fefb87d3e5a83a9c2fe7cdc9720",
+          "version": "1.5.0"
+        }
+      },
+      {
+        "package": "xctest-dynamic-overlay",
+        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
+        "state": {
+          "branch": null,
+          "revision": "6f30bdba373bbd7fbfe241dddd732651f2fbd1e2",
+          "version": "1.1.2"
+        }
       }
-    },
-    {
-      "identity" : "powersync-kotlin",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/powersync-ja/powersync-kotlin.git",
-      "state" : {
-        "revision" : "00d0bfe9800dc39d8cd4dcade5611b744216b842",
-        "version" : "0.0.1-ALPHA5.0"
-      }
-    },
-    {
-      "identity" : "supabase-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/supabase-community/supabase-swift.git",
-      "state" : {
-        "revision" : "08eefdcfc75a8052c1fc0577418cff67d47b6332",
-        "version" : "2.4.0"
-      }
-    },
-    {
-      "identity" : "swift-case-paths",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-case-paths",
-      "state" : {
-        "revision" : "e593aba2c6222daad7c4f2732a431eed2c09bb07",
-        "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
-      "state" : {
-        "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
-        "version" : "1.1.0"
-      }
-    },
-    {
-      "identity" : "swift-concurrency-extras",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
-      "state" : {
-        "revision" : "bb5059bde9022d69ac516803f4f227d8ac967f71",
-        "version" : "1.1.0"
-      }
-    },
-    {
-      "identity" : "swift-crypto",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-crypto.git",
-      "state" : {
-        "revision" : "f0525da24dc3c6cbb2b6b338b65042bc91cbc4bb",
-        "version" : "3.3.0"
-      }
-    },
-    {
-      "identity" : "swift-custom-dump",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-custom-dump",
-      "state" : {
-        "revision" : "f01efb26f3a192a0e88dcdb7c3c391ec2fc25d9c",
-        "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-identified-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-identified-collections.git",
-      "state" : {
-        "revision" : "d1e45f3e1eee2c9193f5369fa9d70a6ddad635e8",
-        "version" : "1.0.0"
-      }
-    },
-    {
-      "identity" : "swift-syntax",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax",
-      "state" : {
-        "revision" : "fa8f95c2d536d6620cc2f504ebe8a6167c9fc2dd",
-        "version" : "510.0.1"
-      }
-    },
-    {
-      "identity" : "swiftui-navigation",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swiftui-navigation.git",
-      "state" : {
-        "revision" : "d9e72f3083c08375794afa216fb2f89c0114f303",
-        "version" : "1.2.1"
-      }
-    },
-    {
-      "identity" : "xctest-dynamic-overlay",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
-      "state" : {
-        "revision" : "b13b1d1a8e787a5ffc71ac19dcaf52183ab27ba2",
-        "version" : "1.1.1"
-      }
-    }
-  ],
-  "version" : 3
+    ]
+  },
+  "version": 1
 }

--- a/PowerSyncExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PowerSyncExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,97 +1,105 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "Supabase",
-        "repositoryURL": "https://github.com/supabase-community/supabase-swift.git",
-        "state": {
-          "branch": null,
-          "revision": "a50157fb848e1748aaf432ed36f71604cfa96d29",
-          "version": "2.13.3"
-        }
-      },
-      {
-        "package": "swift-case-paths",
-        "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
-        "state": {
-          "branch": null,
-          "revision": "b871e5ed11a23e52c2896a92ce2c829982ff8619",
-          "version": "1.4.2"
-        }
-      },
-      {
-        "package": "swift-collections",
-        "repositoryURL": "https://github.com/apple/swift-collections.git",
-        "state": {
-          "branch": null,
-          "revision": "ee97538f5b81ae89698fd95938896dec5217b148",
-          "version": "1.1.1"
-        }
-      },
-      {
-        "package": "swift-concurrency-extras",
-        "repositoryURL": "https://github.com/pointfreeco/swift-concurrency-extras",
-        "state": {
-          "branch": null,
-          "revision": "bb5059bde9022d69ac516803f4f227d8ac967f71",
-          "version": "1.1.0"
-        }
-      },
-      {
-        "package": "swift-crypto",
-        "repositoryURL": "https://github.com/apple/swift-crypto.git",
-        "state": {
-          "branch": null,
-          "revision": "bc1c29221f6dfeb0ebbfbc98eb95cd3d4967868e",
-          "version": "3.4.0"
-        }
-      },
-      {
-        "package": "swift-custom-dump",
-        "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
-        "state": {
-          "branch": null,
-          "revision": "f01efb26f3a192a0e88dcdb7c3c391ec2fc25d9c",
-          "version": "1.3.0"
-        }
-      },
-      {
-        "package": "swift-identified-collections",
-        "repositoryURL": "https://github.com/pointfreeco/swift-identified-collections.git",
-        "state": {
-          "branch": null,
-          "revision": "2f5ab6e091dd032b63dacbda052405756010dc3b",
-          "version": "1.1.0"
-        }
-      },
-      {
-        "package": "swift-syntax",
-        "repositoryURL": "https://github.com/apple/swift-syntax",
-        "state": {
-          "branch": null,
-          "revision": "303e5c5c36d6a558407d364878df131c3546fad8",
-          "version": "510.0.2"
-        }
-      },
-      {
-        "package": "swiftui-navigation",
-        "repositoryURL": "https://github.com/pointfreeco/swiftui-navigation.git",
-        "state": {
-          "branch": null,
-          "revision": "b7c9a79f6f6b1fefb87d3e5a83a9c2fe7cdc9720",
-          "version": "1.5.0"
-        }
-      },
-      {
-        "package": "xctest-dynamic-overlay",
-        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
-        "state": {
-          "branch": null,
-          "revision": "6f30bdba373bbd7fbfe241dddd732651f2fbd1e2",
-          "version": "1.1.2"
-        }
+  "originHash" : "cad047154dd0751ae691260d689c3340e8f7d9d266a58195de31a63e825b9f12",
+  "pins" : [
+    {
+      "identity" : "powersync-kotlin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/powersync-ja/powersync-kotlin.git",
+      "state" : {
+        "revision" : "52fdedecfb62943e0d6ce2347b709fb684ff8cc0",
+        "version" : "0.0.1-ALPHA13.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "supabase-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/supabase-community/supabase-swift.git",
+      "state" : {
+        "revision" : "a50157fb848e1748aaf432ed36f71604cfa96d29",
+        "version" : "2.13.3"
+      }
+    },
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "b871e5ed11a23e52c2896a92ce2c829982ff8619",
+        "version" : "1.4.2"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "ee97538f5b81ae89698fd95938896dec5217b148",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "bb5059bde9022d69ac516803f4f227d8ac967f71",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "bc1c29221f6dfeb0ebbfbc98eb95cd3d4967868e",
+        "version" : "3.4.0"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "f01efb26f3a192a0e88dcdb7c3c391ec2fc25d9c",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-identified-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-identified-collections.git",
+      "state" : {
+        "revision" : "2f5ab6e091dd032b63dacbda052405756010dc3b",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax",
+      "state" : {
+        "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
+        "version" : "510.0.2"
+      }
+    },
+    {
+      "identity" : "swiftui-navigation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swiftui-navigation.git",
+      "state" : {
+        "revision" : "b7c9a79f6f6b1fefb87d3e5a83a9c2fe7cdc9720",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "6f30bdba373bbd7fbfe241dddd732651f2fbd1e2",
+        "version" : "1.1.2"
+      }
+    }
+  ],
+  "version" : 3
 }

--- a/PowerSyncExample/PowerSync.swift
+++ b/PowerSyncExample/PowerSync.swift
@@ -1,5 +1,5 @@
 import Foundation
-import powersyncswift
+import PowerSync
 
 typealias SuspendHandle = () async throws -> Any?
 
@@ -15,7 +15,7 @@ class PowerSync {
         db = PowerSyncBuilderCompanion().from(factory: factory, schema: schema).build()
         
         do {
-            try await db.connect(connector: connector)
+            try await db.connect(connector: connector,crudThrottleMs: 100,retryDelayMs:100)
         } catch {
             print("Unexpected error: \(error.localizedDescription)") // Catches any other error
         }

--- a/PowerSyncExample/PowerSyncExampleApp.swift
+++ b/PowerSyncExample/PowerSyncExampleApp.swift
@@ -1,5 +1,5 @@
 import SwiftUI
-import powersyncswift
+import PowerSync
 import Supabase
 
 @main

--- a/PowerSyncExample/Schema.swift
+++ b/PowerSyncExample/Schema.swift
@@ -1,5 +1,5 @@
 import Foundation
-import powersyncswift
+import PowerSync
 
 
 func createSchema() -> Schema {

--- a/PowerSyncExample/Supabase/SupabaseConnector.swift
+++ b/PowerSyncExample/Supabase/SupabaseConnector.swift
@@ -1,7 +1,7 @@
 import Auth
 import SwiftUI
 import Supabase
-import powersyncswift
+import PowerSync
 
 
 @Observable
@@ -45,8 +45,7 @@ class SupabaseConnector: PowerSyncBackendConnector {
         if((self.session == nil)){
             throw AuthError.sessionNotFound
         }
-        return PowerSyncCredentials(endpoint: self.powerSyncEndpoint, token: session!.accessToken, userId: currentUserID,
-                                    expiresAt: sessionExpiresAt)
+        return PowerSyncCredentials(endpoint: self.powerSyncEndpoint, token: session!.accessToken, userId: currentUserID)
     }
     
     override func __uploadData(database: any PowerSyncDatabase) async throws {


### PR DESCRIPTION
## Description
This is to update the Demo to the latest Swift package changes and package name change as found in this PR https://github.com/powersync-ja/powersync-kotlin/compare/chore/rename-package-and-clean-up?expand=1 . This PR also includes a video showing this working.

## Work Done
* Updated package imports to use new package name `PowerSync`
* Updated connect to use required fields
* Added a Swift default `.gitignore` file