### PR TITLE
fix: update uncomplete todo

### DIFF
--- a/PowerSyncExample/PowerSync/PowerSync.swift
+++ b/PowerSyncExample/PowerSync/PowerSync.swift
@@ -121,8 +121,8 @@ class PowerSync {
             )
         } else {
             try await self.db.execute(
-                sql: "UPDATE \(TODOS_TABLE) SET description = ?, completed = ?, completed_at = NULL, completed_by = ? WHERE id = ?",
-                parameters: [todo.description, todo.isComplete, connector.currentUserID, todo.id]
+                sql: "UPDATE \(TODOS_TABLE) SET description = ?, completed = ?, completed_at = NULL, completed_by = NULL WHERE id = ?",
+                parameters: [todo.description, todo.isComplete, todo.id]
             )
         }
     }


### PR DESCRIPTION
## Description
There is an error when updating the todo to incomplete where it is not nullifying the `completed_by` field. This fixes that.