### PR TITLE
chore: update powersync package version

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - powersync-sqlite-core (0.1.6)
+  - powersync-sqlite-core (0.1.8)
 
 DEPENDENCIES:
-  - powersync-sqlite-core (~> 0.1.6)
+  - powersync-sqlite-core (~> 0.1.7)
 
 SPEC REPOS:
   trunk:
     - powersync-sqlite-core
 
 SPEC CHECKSUMS:
-  powersync-sqlite-core: 4c38c8f470f6dca61346789fd5436a6826d1e3dd
+  powersync-sqlite-core: 9325150c88515df0b5ea992007708588c3f01518
 
-PODFILE CHECKSUM: e4a7ca10ec7d888dc59523e97b78968bfff30f54
+PODFILE CHECKSUM: 8cf511c85a2b785572c3553be7e62c9ab52dfd96
 
 COCOAPODS: 1.15.2

--- a/PowerSyncExample.xcodeproj/project.pbxproj
+++ b/PowerSyncExample.xcodeproj/project.pbxproj
@@ -14,9 +14,6 @@
 		6A73158C2B9854240004CB17 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6A73158B2B9854240004CB17 /* Assets.xcassets */; };
 		6A73158F2B9854240004CB17 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6A73158E2B9854240004CB17 /* Preview Assets.xcassets */; };
 		6A7315BB2B98BDD30004CB17 /* PowerSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7315BA2B98BDD30004CB17 /* PowerSync.swift */; };
-		6A9668FE2B9EE4FE00B05DCF /* Auth in Frameworks */ = {isa = PBXBuildFile; productRef = 6A9668FD2B9EE4FE00B05DCF /* Auth */; };
-		6A9669002B9EE4FE00B05DCF /* PostgREST in Frameworks */ = {isa = PBXBuildFile; productRef = 6A9668FF2B9EE4FE00B05DCF /* PostgREST */; };
-		6A9669022B9EE69500B05DCF /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = 6A9669012B9EE69500B05DCF /* Supabase */; };
 		6A9669042B9EE6FA00B05DCF /* SignInScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A9669032B9EE6FA00B05DCF /* SignInScreen.swift */; };
 		6ABD78672B9F2B4800558A41 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ABD78662B9F2B4800558A41 /* RootView.swift */; };
 		6ABD786B2B9F2C1500558A41 /* TodoListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ABD786A2B9F2C1500558A41 /* TodoListView.swift */; };
@@ -34,11 +31,11 @@
 		B66658632C621CA700159A81 /* AddTodoListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66658622C621CA700159A81 /* AddTodoListView.swift */; };
 		B66658652C62314B00159A81 /* Lists.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66658642C62314B00159A81 /* Lists.swift */; };
 		B66658672C62315400159A81 /* Todos.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66658662C62315400159A81 /* Todos.swift */; };
-		B66658772C63B7BB00159A81 /* IdentifiedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = B66658762C63B7BB00159A81 /* IdentifiedCollections */; };
-		B666587A2C63B88700159A81 /* SwiftUINavigation in Frameworks */ = {isa = PBXBuildFile; productRef = B66658792C63B88700159A81 /* SwiftUINavigation */; };
-		B666587C2C63B88700159A81 /* SwiftUINavigationCore in Frameworks */ = {isa = PBXBuildFile; productRef = B666587B2C63B88700159A81 /* SwiftUINavigationCore */; };
 		B6B3698A2C64F4B30033C307 /* Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B369892C64F4B30033C307 /* Navigation.swift */; };
-		B6C77B982C253C9B0082993E /* PowerSync in Frameworks */ = {isa = PBXBuildFile; productRef = B6C77B972C253C9B0082993E /* PowerSync */; };
+		B6C634DC2C7C9C0F00D44E72 /* SwiftUINavigation in Frameworks */ = {isa = PBXBuildFile; productRef = B6C634DB2C7C9C0F00D44E72 /* SwiftUINavigation */; };
+		B6C634DE2C7C9C0F00D44E72 /* SwiftUINavigationCore in Frameworks */ = {isa = PBXBuildFile; productRef = B6C634DD2C7C9C0F00D44E72 /* SwiftUINavigationCore */; };
+		B6C634E12C7C9C2100D44E72 /* IdentifiedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = B6C634E02C7C9C2100D44E72 /* IdentifiedCollections */; };
+		B6C634F02C7CC9CE00D44E72 /* AnyCodable in Frameworks */ = {isa = PBXBuildFile; productRef = B6C634EF2C7CC9CE00D44E72 /* AnyCodable */; };
 		BD51A7EE25913C8BC8773347 /* Pods_PowerSyncExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7DD2B4628A3E02C0428D058C /* Pods_PowerSyncExample.framework */; };
 /* End PBXBuildFile section */
 
@@ -115,14 +112,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B66658772C63B7BB00159A81 /* IdentifiedCollections in Frameworks */,
-				B666587C2C63B88700159A81 /* SwiftUINavigationCore in Frameworks */,
-				B6C77B982C253C9B0082993E /* PowerSync in Frameworks */,
-				6A9669022B9EE69500B05DCF /* Supabase in Frameworks */,
-				6A9669002B9EE4FE00B05DCF /* PostgREST in Frameworks */,
-				6A9668FE2B9EE4FE00B05DCF /* Auth in Frameworks */,
-				B666587A2C63B88700159A81 /* SwiftUINavigation in Frameworks */,
+				B6C634DC2C7C9C0F00D44E72 /* SwiftUINavigation in Frameworks */,
+				B6C634E12C7C9C2100D44E72 /* IdentifiedCollections in Frameworks */,
+				B6C634DE2C7C9C0F00D44E72 /* SwiftUINavigationCore in Frameworks */,
 				BD51A7EE25913C8BC8773347 /* Pods_PowerSyncExample.framework in Frameworks */,
+				B6C634F02C7CC9CE00D44E72 /* AnyCodable in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -229,15 +223,6 @@
 				B66658662C62315400159A81 /* Todos.swift */,
 			);
 			path = PowerSync;
-			sourceTree = "<group>";
-		};
-		AE7193DCE091DC4BD17BE54E /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				23423475D5EF090FBC543BC3 /* Pods-PowerSyncExample.debug.xcconfig */,
-				14B25A4E5C92F258ADCF4F59 /* Pods-PowerSyncExample.release.xcconfig */,
-			);
-			path = Pods;
 			sourceTree = "<group>";
 		};
 		B6F4210F2BC42F450005D0D0 /* natives */ = {
@@ -486,16 +471,18 @@
 			buildRules = (
 			);
 			dependencies = (
+				B6C634F42C7CCC2C00D44E72 /* PBXTargetDependency */,
+				B6C634F22C7CCC2900D44E72 /* PBXTargetDependency */,
+				B6C634ED2C7CC5E400D44E72 /* PBXTargetDependency */,
+				B6C634EB2C7CC5D900D44E72 /* PBXTargetDependency */,
+				B6C634E72C7CC5BD00D44E72 /* PBXTargetDependency */,
 			);
 			name = PowerSyncExample;
 			packageProductDependencies = (
-				6A9668FD2B9EE4FE00B05DCF /* Auth */,
-				6A9668FF2B9EE4FE00B05DCF /* PostgREST */,
-				6A9669012B9EE69500B05DCF /* Supabase */,
-				B6C77B972C253C9B0082993E /* PowerSync */,
-				B66658762C63B7BB00159A81 /* IdentifiedCollections */,
-				B66658792C63B88700159A81 /* SwiftUINavigation */,
-				B666587B2C63B88700159A81 /* SwiftUINavigationCore */,
+				B6C634DB2C7C9C0F00D44E72 /* SwiftUINavigation */,
+				B6C634DD2C7C9C0F00D44E72 /* SwiftUINavigationCore */,
+				B6C634E02C7C9C2100D44E72 /* IdentifiedCollections */,
+				B6C634EF2C7CC9CE00D44E72 /* AnyCodable */,
 			);
 			productName = PowerSyncExample;
 			productReference = 6A7315842B9854220004CB17 /* PowerSyncExample.app */;
@@ -527,10 +514,11 @@
 			);
 			mainGroup = 6A73157B2B9854220004CB17;
 			packageReferences = (
-				6A9668FC2B9EE4FE00B05DCF /* XCRemoteSwiftPackageReference "supabase-swift" */,
-				B6C77B962C253C9B0082993E /* XCRemoteSwiftPackageReference "powersync-kotlin" */,
-				B66658752C63B7BB00159A81 /* XCRemoteSwiftPackageReference "swift-identified-collections" */,
-				B66658782C63B88700159A81 /* XCRemoteSwiftPackageReference "swiftui-navigation" */,
+				B6C634DA2C7C9C0F00D44E72 /* XCRemoteSwiftPackageReference "swiftui-navigation" */,
+				B6C634DF2C7C9C2100D44E72 /* XCRemoteSwiftPackageReference "swift-identified-collections" */,
+				B6C634E32C7C9CE100D44E72 /* XCRemoteSwiftPackageReference "supabase-swift" */,
+				B6C634E52C7CC41200D44E72 /* XCRemoteSwiftPackageReference "powersync-kotlin" */,
+				B6C634EE2C7CC9CE00D44E72 /* XCRemoteSwiftPackageReference "AnyCodable" */,
 			);
 			productRefGroup = 6A7315852B9854220004CB17 /* Products */;
 			projectDirPath = "";
@@ -627,6 +615,29 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		B6C634E72C7CC5BD00D44E72 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = B6C634E62C7CC5BD00D44E72 /* Supabase */;
+		};
+		B6C634EB2C7CC5D900D44E72 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = B6C634EA2C7CC5D900D44E72 /* PowerSync */;
+		};
+		B6C634ED2C7CC5E400D44E72 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = B6C634EC2C7CC5E400D44E72 /* IdentifiedCollections */;
+		};
+		B6C634F22C7CCC2900D44E72 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = B6C634F12C7CCC2900D44E72 /* PostgREST */;
+		};
+		B6C634F42C7CCC2C00D44E72 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = B6C634F32C7CCC2C00D44E72 /* Auth */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		6A7315902B9854240004CB17 /* Debug */ = {
@@ -847,15 +858,15 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		6A9668FC2B9EE4FE00B05DCF /* XCRemoteSwiftPackageReference "supabase-swift" */ = {
+		B6C634DA2C7C9C0F00D44E72 /* XCRemoteSwiftPackageReference "swiftui-navigation" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/supabase-community/supabase-swift.git";
+			repositoryURL = "https://github.com/pointfreeco/swiftui-navigation";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.4.0;
+				minimumVersion = 1.5.5;
 			};
 		};
-		B66658752C63B7BB00159A81 /* XCRemoteSwiftPackageReference "swift-identified-collections" */ = {
+		B6C634DF2C7C9C2100D44E72 /* XCRemoteSwiftPackageReference "swift-identified-collections" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pointfreeco/swift-identified-collections";
 			requirement = {
@@ -863,59 +874,77 @@
 				minimumVersion = 1.1.0;
 			};
 		};
-		B66658782C63B88700159A81 /* XCRemoteSwiftPackageReference "swiftui-navigation" */ = {
+		B6C634E32C7C9CE100D44E72 /* XCRemoteSwiftPackageReference "supabase-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/pointfreeco/swiftui-navigation";
+			repositoryURL = "https://github.com/supabase/supabase-swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.5.4;
+				minimumVersion = 2.5.1;
 			};
 		};
-		B6C77B962C253C9B0082993E /* XCRemoteSwiftPackageReference "powersync-kotlin" */ = {
+		B6C634E52C7CC41200D44E72 /* XCRemoteSwiftPackageReference "powersync-kotlin" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/powersync-ja/powersync-kotlin";
 			requirement = {
 				kind = exactVersion;
-				version = "0.0.1-ALPHA15.0";
+				version = "0.0.1-ALPHA17.0";
+			};
+		};
+		B6C634EE2C7CC9CE00D44E72 /* XCRemoteSwiftPackageReference "AnyCodable" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Flight-School/AnyCodable";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.6.7;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		6A9668FD2B9EE4FE00B05DCF /* Auth */ = {
+		B6C634DB2C7C9C0F00D44E72 /* SwiftUINavigation */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 6A9668FC2B9EE4FE00B05DCF /* XCRemoteSwiftPackageReference "supabase-swift" */;
-			productName = Auth;
-		};
-		6A9668FF2B9EE4FE00B05DCF /* PostgREST */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 6A9668FC2B9EE4FE00B05DCF /* XCRemoteSwiftPackageReference "supabase-swift" */;
-			productName = PostgREST;
-		};
-		6A9669012B9EE69500B05DCF /* Supabase */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 6A9668FC2B9EE4FE00B05DCF /* XCRemoteSwiftPackageReference "supabase-swift" */;
-			productName = Supabase;
-		};
-		B66658762C63B7BB00159A81 /* IdentifiedCollections */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = B66658752C63B7BB00159A81 /* XCRemoteSwiftPackageReference "swift-identified-collections" */;
-			productName = IdentifiedCollections;
-		};
-		B66658792C63B88700159A81 /* SwiftUINavigation */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = B66658782C63B88700159A81 /* XCRemoteSwiftPackageReference "swiftui-navigation" */;
+			package = B6C634DA2C7C9C0F00D44E72 /* XCRemoteSwiftPackageReference "swiftui-navigation" */;
 			productName = SwiftUINavigation;
 		};
-		B666587B2C63B88700159A81 /* SwiftUINavigationCore */ = {
+		B6C634DD2C7C9C0F00D44E72 /* SwiftUINavigationCore */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = B66658782C63B88700159A81 /* XCRemoteSwiftPackageReference "swiftui-navigation" */;
+			package = B6C634DA2C7C9C0F00D44E72 /* XCRemoteSwiftPackageReference "swiftui-navigation" */;
 			productName = SwiftUINavigationCore;
 		};
-		B6C77B972C253C9B0082993E /* PowerSync */ = {
+		B6C634E02C7C9C2100D44E72 /* IdentifiedCollections */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = B6C77B962C253C9B0082993E /* XCRemoteSwiftPackageReference "powersync-kotlin" */;
+			package = B6C634DF2C7C9C2100D44E72 /* XCRemoteSwiftPackageReference "swift-identified-collections" */;
+			productName = IdentifiedCollections;
+		};
+		B6C634E62C7CC5BD00D44E72 /* Supabase */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B6C634E32C7C9CE100D44E72 /* XCRemoteSwiftPackageReference "supabase-swift" */;
+			productName = Supabase;
+		};
+		B6C634EA2C7CC5D900D44E72 /* PowerSync */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B6C634E52C7CC41200D44E72 /* XCRemoteSwiftPackageReference "powersync-kotlin" */;
 			productName = PowerSync;
+		};
+		B6C634EC2C7CC5E400D44E72 /* IdentifiedCollections */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B6C634DF2C7C9C2100D44E72 /* XCRemoteSwiftPackageReference "swift-identified-collections" */;
+			productName = IdentifiedCollections;
+		};
+		B6C634EF2C7CC9CE00D44E72 /* AnyCodable */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B6C634EE2C7CC9CE00D44E72 /* XCRemoteSwiftPackageReference "AnyCodable" */;
+			productName = AnyCodable;
+		};
+		B6C634F12C7CCC2900D44E72 /* PostgREST */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B6C634E32C7C9CE100D44E72 /* XCRemoteSwiftPackageReference "supabase-swift" */;
+			productName = PostgREST;
+		};
+		B6C634F32C7CCC2C00D44E72 /* Auth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B6C634E32C7C9CE100D44E72 /* XCRemoteSwiftPackageReference "supabase-swift" */;
+			productName = Auth;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/PowerSyncExample.xcodeproj/project.pbxproj
+++ b/PowerSyncExample.xcodeproj/project.pbxproj
@@ -887,7 +887,7 @@
 			repositoryURL = "https://github.com/powersync-ja/powersync-kotlin";
 			requirement = {
 				kind = exactVersion;
-				version = "0.0.1-ALPHA17.0";
+				version = "1.0.0-BETA1.0";
 			};
 		};
 		B6C634EE2C7CC9CE00D44E72 /* XCRemoteSwiftPackageReference "AnyCodable" */ = {

--- a/PowerSyncExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PowerSyncExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,97 +1,114 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "supabase-swift",
-        "repositoryURL": "https://github.com/supabase-community/supabase-swift.git",
-        "state": {
-          "branch": null,
-          "revision": "42a22357c290992d1b548dc153c23fc96bf12ff9",
-          "version": "2.15.3"
-        }
-      },
-      {
-        "package": "swift-case-paths",
-        "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
-        "state": {
-          "branch": null,
-          "revision": "71344dd930fde41e8f3adafe260adcbb2fc2a3dc",
-          "version": "1.5.4"
-        }
-      },
-      {
-        "package": "swift-collections",
-        "repositoryURL": "https://github.com/apple/swift-collections",
-        "state": {
-          "branch": null,
-          "revision": "3d2dc41a01f9e49d84f0a3925fb858bed64f702d",
-          "version": "1.1.2"
-        }
-      },
-      {
-        "package": "swift-concurrency-extras",
-        "repositoryURL": "https://github.com/pointfreeco/swift-concurrency-extras",
-        "state": {
-          "branch": null,
-          "revision": "bb5059bde9022d69ac516803f4f227d8ac967f71",
-          "version": "1.1.0"
-        }
-      },
-      {
-        "package": "swift-crypto",
-        "repositoryURL": "https://github.com/apple/swift-crypto.git",
-        "state": {
-          "branch": null,
-          "revision": "8dafe0fdce623f65178689f2d6dea7304f7fbe75",
-          "version": "3.6.0"
-        }
-      },
-      {
-        "package": "swift-custom-dump",
-        "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
-        "state": {
-          "branch": null,
-          "revision": "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
-          "version": "1.3.3"
-        }
-      },
-      {
-        "package": "swift-identified-collections",
-        "repositoryURL": "https://github.com/pointfreeco/swift-identified-collections",
-        "state": {
-          "branch": null,
-          "revision": "2f5ab6e091dd032b63dacbda052405756010dc3b",
-          "version": "1.1.0"
-        }
-      },
-      {
-        "package": "swift-syntax",
-        "repositoryURL": "https://github.com/swiftlang/swift-syntax",
-        "state": {
-          "branch": null,
-          "revision": "06b5cdc432e93b60e3bdf53aff2857c6b312991a",
-          "version": "600.0.0-prerelease-2024-07-30"
-        }
-      },
-      {
-        "package": "swiftui-navigation",
-        "repositoryURL": "https://github.com/pointfreeco/swiftui-navigation",
-        "state": {
-          "branch": null,
-          "revision": "fc91d591ebba1f90d65028ccb65c861e5979e898",
-          "version": "1.5.4"
-        }
-      },
-      {
-        "package": "xctest-dynamic-overlay",
-        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
-        "state": {
-          "branch": null,
-          "revision": "357ca1e5dd31f613a1d43320870ebc219386a495",
-          "version": "1.2.2"
-        }
+  "originHash" : "637dd32804b8a40724484a44a4078103b51a1aa471c6a65e9080d97a460fd948",
+  "pins" : [
+    {
+      "identity" : "anycodable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Flight-School/AnyCodable",
+      "state" : {
+        "revision" : "862808b2070cd908cb04f9aafe7de83d35f81b05",
+        "version" : "0.6.7"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "powersync-kotlin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/powersync-ja/powersync-kotlin",
+      "state" : {
+        "revision" : "275d851178f03e2dd7c6837b2cacf4ddc1900fbc",
+        "version" : "0.0.1-ALPHA17.0"
+      }
+    },
+    {
+      "identity" : "supabase-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/supabase/supabase-swift.git",
+      "state" : {
+        "revision" : "4c966eafaaebc893a418e6334ef67beb0287a9ad",
+        "version" : "2.16.1"
+      }
+    },
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "71344dd930fde41e8f3adafe260adcbb2fc2a3dc",
+        "version" : "1.5.4"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "3d2dc41a01f9e49d84f0a3925fb858bed64f702d",
+        "version" : "1.1.2"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "bb5059bde9022d69ac516803f4f227d8ac967f71",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "a53a7e8f858902659d4784322bede34f4e49097e",
+        "version" : "3.6.1"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
+      }
+    },
+    {
+      "identity" : "swift-identified-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-identified-collections",
+      "state" : {
+        "revision" : "2f5ab6e091dd032b63dacbda052405756010dc3b",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "06b5cdc432e93b60e3bdf53aff2857c6b312991a",
+        "version" : "600.0.0-prerelease-2024-07-30"
+      }
+    },
+    {
+      "identity" : "swiftui-navigation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swiftui-navigation",
+      "state" : {
+        "revision" : "e628806aeaa9efe25c1abcd97931a7c498fab281",
+        "version" : "1.5.5"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "357ca1e5dd31f613a1d43320870ebc219386a495",
+        "version" : "1.2.2"
+      }
+    }
+  ],
+  "version" : 3
 }

--- a/PowerSyncExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PowerSyncExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "637dd32804b8a40724484a44a4078103b51a1aa471c6a65e9080d97a460fd948",
+  "originHash" : "54b6be17fa944d159f8c9668342e49512dec9840b4ced5976094d2ae8217775b",
   "pins" : [
     {
       "identity" : "anycodable",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/powersync-ja/powersync-kotlin",
       "state" : {
-        "revision" : "275d851178f03e2dd7c6837b2cacf4ddc1900fbc",
-        "version" : "0.0.1-ALPHA17.0"
+        "revision" : "43198bfc4519563e05052fbab5becb3e18960186",
+        "version" : "1.0.0-BETA1.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/supabase/supabase-swift.git",
       "state" : {
-        "revision" : "4c966eafaaebc893a418e6334ef67beb0287a9ad",
-        "version" : "2.16.1"
+        "revision" : "b0059a3f30a6a3a7d3b96f786542234a5d1a7835",
+        "version" : "2.18.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "71344dd930fde41e8f3adafe260adcbb2fc2a3dc",
-        "version" : "1.5.4"
+        "revision" : "642e6aab8e03e5f992d9c83e38c5be98cfad5078",
+        "version" : "1.5.5"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "3d2dc41a01f9e49d84f0a3925fb858bed64f702d",
-        "version" : "1.1.2"
+        "revision" : "9bf03ff58ce34478e66aaee630e491823326fd06",
+        "version" : "1.1.3"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "a53a7e8f858902659d4784322bede34f4e49097e",
-        "version" : "3.6.1"
+        "revision" : "9f95b4d033a4edd3814b48608db3f2ca90c7218b",
+        "version" : "3.7.0"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "06b5cdc432e93b60e3bdf53aff2857c6b312991a",
-        "version" : "600.0.0-prerelease-2024-07-30"
+        "revision" : "515f79b522918f83483068d99c68daeb5116342d",
+        "version" : "600.0.0-prerelease-2024-09-04"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "357ca1e5dd31f613a1d43320870ebc219386a495",
-        "version" : "1.2.2"
+        "revision" : "96beb108a57f24c8476ae1f309239270772b2940",
+        "version" : "1.2.5"
       }
     }
   ],

--- a/PowerSyncExample/PowerSync/PowerSync.swift
+++ b/PowerSyncExample/PowerSync/PowerSync.swift
@@ -38,11 +38,15 @@ class PowerSync {
     }
 
     func writeTransaction(_ queryHandle: @escaping () async throws -> Any) async throws -> Any? {
-        try await db.writeTransaction(body: SuspendTaskWrapper(queryHandle))
+        try await db.writeTransaction(callback: SuspendTaskWrapper(queryHandle)){_,_ in 
+        
+        }
     }
 
     func readTransaction(_ queryHandle: @escaping () async throws -> Any) async throws -> Any? {
-        try await db.readTransaction(body: SuspendTaskWrapper(queryHandle))
+        try await db.readTransaction(callback: SuspendTaskWrapper(queryHandle)) {_,_ in 
+            
+        }
     }
 
     func watchLists(_ cb: @escaping (_ lists: [ListContent]) -> Void ) async {
@@ -70,7 +74,7 @@ class PowerSync {
     }
 
     func deleteList(id: String) async throws {
-        try await db.writeTransaction(body: SuspendTaskWrapper {
+        try await db.writeTransaction(callback: SuspendTaskWrapper {
             try await self.db.execute(
                 sql: "DELETE FROM \(LISTS_TABLE) WHERE id = ?",
                 parameters: [id]
@@ -128,7 +132,7 @@ class PowerSync {
     }
 
     func deleteTodo(id: String) async throws {
-        try await db.writeTransaction(body: SuspendTaskWrapper {
+        try await db.writeTransaction(callback: SuspendTaskWrapper {
             try await self.db.execute(
                 sql: "DELETE FROM \(TODOS_TABLE) WHERE id = ?",
                 parameters: [id]

--- a/PowerSyncExample/PowerSync/PowerSync.swift
+++ b/PowerSyncExample/PowerSync/PowerSync.swift
@@ -38,15 +38,11 @@ class PowerSync {
     }
 
     func writeTransaction(_ queryHandle: @escaping () async throws -> Any) async throws -> Any? {
-        try await db.writeTransaction(callback: SuspendTaskWrapper(queryHandle)){_,_ in 
-        
-        }
+        try await db.writeTransaction(callback: SuspendTaskWrapper(queryHandle))
     }
 
     func readTransaction(_ queryHandle: @escaping () async throws -> Any) async throws -> Any? {
-        try await db.readTransaction(callback: SuspendTaskWrapper(queryHandle)) {_,_ in 
-            
-        }
+        try await db.readTransaction(callback: SuspendTaskWrapper(queryHandle))
     }
 
     func watchLists(_ cb: @escaping (_ lists: [ListContent]) -> Void ) async {

--- a/PowerSyncExample/PowerSync/Schema.swift
+++ b/PowerSyncExample/PowerSync/Schema.swift
@@ -15,7 +15,7 @@ let lists = Table(
     indexes: [],
     localOnly: false,
     insertOnly: false,
-    _viewNameOverride: LISTS_TABLE
+    viewNameOverride: LISTS_TABLE
 )
 
 let todos = Table(
@@ -41,7 +41,7 @@ let todos = Table(
     ],
     localOnly: false,
     insertOnly: false,
-    _viewNameOverride: TODOS_TABLE
+    viewNameOverride: TODOS_TABLE
 )
 
 let AppSchema = Schema(tables: [lists, todos])

--- a/PowerSyncExample/PowerSync/SupabaseConnector.swift
+++ b/PowerSyncExample/PowerSync/SupabaseConnector.swift
@@ -1,7 +1,7 @@
-import Auth
 import SwiftUI
 import Supabase
 import PowerSync
+import AnyCodable
 
 @Observable
 @MainActor
@@ -62,12 +62,13 @@ class SupabaseConnector: PowerSyncBackendConnector {
 
                 switch entry.op {
                 case .put:
-                    var data = entry.opData ?? [String: String]()
-                    data["id"] = entry.id
+                    var data: [String: AnyCodable] = entry.opData?.mapValues { AnyCodable($0) } ?? [:]
+                    data["id"] = AnyCodable(entry.id)
                     try await table.upsert(data).execute();
                 case .patch:
                     guard let opData = entry.opData else { continue }
-                    try await table.update(opData).eq("id", value: entry.id).execute()
+                    let encodableData = opData.mapValues { AnyCodable($0) }
+                    try await table.update(encodableData).eq("id", value: entry.id).execute()
 
                 case .delete:
                     try await table.delete().eq( "id", value: entry.id).execute()

--- a/README.md
+++ b/README.md
@@ -63,32 +63,6 @@ You can obtain your PowerSync Instance URL by following these steps:
 - Click "Edit instance"
 - Click on "Instance URL" to copy the value
 
-## Configure Xcode access to SDK binary
-
-The below steps are required by [KMMBridge](https://touchlab.co/quick-start-with-kmmbridge-1-hour-tutorial#configure-xcode-clients):
-
-### Create GitHub Personal Access Token (PAT)
-
-In your GitHub:
-
-1. Under your user account, navigate to “Settings” -> “Developer Settings” -> “Personal access tokens” -> “Tokens (classic)”
-2. Click “Generate new token” and select “Generate new token (classic)”
-3. Given the token a name e.g. PowerSync XCode
-4. Set the expiration date to “No expiration”, since we won’t be giving this token any sensitive privileges
-5. Under “Select scopes”, enable the “read:packages” checkbox (don’t need “write:packages”)
-6. Click Generate Token
-7. Copy the value for the next step
-
-### Create .netrc file
-
-1. Create a file `~/.netrc` with the following contents:
-
-```
-machine maven.pkg.github.com
-  login [your GitHub username]
-  password [your PAT from the previous step]
-```
-
 ### Finish XCode configuration
 
 1. Clear Swift caches

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ rm -rf ~/Library/org.swift.swiftpm
 - Reset Packages: File -> Packages -> Reset Package Caches
 - Clean Build: Product -> Clean Build Folder.
 
+4. Enable CasePathMacros. We are using SwiftUI Navigation for the demo which requires this.
+
 ## Run project
 
 Build the project, launch the app and sign in with the test user you created in Supabase earlier.


### PR DESCRIPTION
## Description
Updated to latest version BETA1.0, which required some argument naming changes. 

It also appears Supabase released an update that requires us to have an encodable type for opData. This required the use of the `AnyCodable` package so that we can get the typing right for opData which is dynamic.

Lastly, I removed references in the doc from netrc setup and added a note about enabling `CasePathMacro`