### PR TITLE
chore: update packages with changes and readme updates to move to open alpha

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - powersync-sqlite-core (0.1.6)
+  - powersync-sqlite-core (0.1.8)
 
 DEPENDENCIES:
-  - powersync-sqlite-core (~> 0.1.6)
+  - powersync-sqlite-core (~> 0.1.7)
 
 SPEC REPOS:
   trunk:
     - powersync-sqlite-core
 
 SPEC CHECKSUMS:
-  powersync-sqlite-core: 4c38c8f470f6dca61346789fd5436a6826d1e3dd
+  powersync-sqlite-core: 9325150c88515df0b5ea992007708588c3f01518
 
-PODFILE CHECKSUM: e4a7ca10ec7d888dc59523e97b78968bfff30f54
+PODFILE CHECKSUM: 8cf511c85a2b785572c3553be7e62c9ab52dfd96
 
 COCOAPODS: 1.15.2

--- a/PowerSyncExample.xcodeproj/project.pbxproj
+++ b/PowerSyncExample.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		B66658772C63B7BB00159A81 /* IdentifiedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = B66658762C63B7BB00159A81 /* IdentifiedCollections */; };
 		B666587A2C63B88700159A81 /* SwiftUINavigation in Frameworks */ = {isa = PBXBuildFile; productRef = B66658792C63B88700159A81 /* SwiftUINavigation */; };
 		B666587C2C63B88700159A81 /* SwiftUINavigationCore in Frameworks */ = {isa = PBXBuildFile; productRef = B666587B2C63B88700159A81 /* SwiftUINavigationCore */; };
+		B69F7D862C8EE27400565448 /* AnyCodable in Frameworks */ = {isa = PBXBuildFile; productRef = B69F7D852C8EE27400565448 /* AnyCodable */; };
 		B6B3698A2C64F4B30033C307 /* Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B369892C64F4B30033C307 /* Navigation.swift */; };
 		B6C77B982C253C9B0082993E /* PowerSync in Frameworks */ = {isa = PBXBuildFile; productRef = B6C77B972C253C9B0082993E /* PowerSync */; };
 		BD51A7EE25913C8BC8773347 /* Pods_PowerSyncExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7DD2B4628A3E02C0428D058C /* Pods_PowerSyncExample.framework */; };
@@ -116,6 +117,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B66658772C63B7BB00159A81 /* IdentifiedCollections in Frameworks */,
+				B69F7D862C8EE27400565448 /* AnyCodable in Frameworks */,
 				B666587C2C63B88700159A81 /* SwiftUINavigationCore in Frameworks */,
 				B6C77B982C253C9B0082993E /* PowerSync in Frameworks */,
 				6A9669022B9EE69500B05DCF /* Supabase in Frameworks */,
@@ -229,15 +231,6 @@
 				B66658662C62315400159A81 /* Todos.swift */,
 			);
 			path = PowerSync;
-			sourceTree = "<group>";
-		};
-		AE7193DCE091DC4BD17BE54E /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				23423475D5EF090FBC543BC3 /* Pods-PowerSyncExample.debug.xcconfig */,
-				14B25A4E5C92F258ADCF4F59 /* Pods-PowerSyncExample.release.xcconfig */,
-			);
-			path = Pods;
 			sourceTree = "<group>";
 		};
 		B6F4210F2BC42F450005D0D0 /* natives */ = {
@@ -496,6 +489,7 @@
 				B66658762C63B7BB00159A81 /* IdentifiedCollections */,
 				B66658792C63B88700159A81 /* SwiftUINavigation */,
 				B666587B2C63B88700159A81 /* SwiftUINavigationCore */,
+				B69F7D852C8EE27400565448 /* AnyCodable */,
 			);
 			productName = PowerSyncExample;
 			productReference = 6A7315842B9854220004CB17 /* PowerSyncExample.app */;
@@ -531,6 +525,7 @@
 				B6C77B962C253C9B0082993E /* XCRemoteSwiftPackageReference "powersync-kotlin" */,
 				B66658752C63B7BB00159A81 /* XCRemoteSwiftPackageReference "swift-identified-collections" */,
 				B66658782C63B88700159A81 /* XCRemoteSwiftPackageReference "swiftui-navigation" */,
+				B69F7D842C8EE27300565448 /* XCRemoteSwiftPackageReference "AnyCodable" */,
 			);
 			productRefGroup = 6A7315852B9854220004CB17 /* Products */;
 			projectDirPath = "";
@@ -871,12 +866,20 @@
 				minimumVersion = 1.5.4;
 			};
 		};
+		B69F7D842C8EE27300565448 /* XCRemoteSwiftPackageReference "AnyCodable" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Flight-School/AnyCodable";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.6.7;
+			};
+		};
 		B6C77B962C253C9B0082993E /* XCRemoteSwiftPackageReference "powersync-kotlin" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/powersync-ja/powersync-kotlin";
 			requirement = {
 				kind = exactVersion;
-				version = "0.0.1-ALPHA15.0";
+				version = "1.0.0-BETA1.0";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -911,6 +914,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = B66658782C63B88700159A81 /* XCRemoteSwiftPackageReference "swiftui-navigation" */;
 			productName = SwiftUINavigationCore;
+		};
+		B69F7D852C8EE27400565448 /* AnyCodable */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B69F7D842C8EE27300565448 /* XCRemoteSwiftPackageReference "AnyCodable" */;
+			productName = AnyCodable;
 		};
 		B6C77B972C253C9B0082993E /* PowerSync */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/PowerSyncExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PowerSyncExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,97 +1,114 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "supabase-swift",
-        "repositoryURL": "https://github.com/supabase-community/supabase-swift.git",
-        "state": {
-          "branch": null,
-          "revision": "42a22357c290992d1b548dc153c23fc96bf12ff9",
-          "version": "2.15.3"
-        }
-      },
-      {
-        "package": "swift-case-paths",
-        "repositoryURL": "https://github.com/pointfreeco/swift-case-paths",
-        "state": {
-          "branch": null,
-          "revision": "71344dd930fde41e8f3adafe260adcbb2fc2a3dc",
-          "version": "1.5.4"
-        }
-      },
-      {
-        "package": "swift-collections",
-        "repositoryURL": "https://github.com/apple/swift-collections",
-        "state": {
-          "branch": null,
-          "revision": "3d2dc41a01f9e49d84f0a3925fb858bed64f702d",
-          "version": "1.1.2"
-        }
-      },
-      {
-        "package": "swift-concurrency-extras",
-        "repositoryURL": "https://github.com/pointfreeco/swift-concurrency-extras",
-        "state": {
-          "branch": null,
-          "revision": "bb5059bde9022d69ac516803f4f227d8ac967f71",
-          "version": "1.1.0"
-        }
-      },
-      {
-        "package": "swift-crypto",
-        "repositoryURL": "https://github.com/apple/swift-crypto.git",
-        "state": {
-          "branch": null,
-          "revision": "8dafe0fdce623f65178689f2d6dea7304f7fbe75",
-          "version": "3.6.0"
-        }
-      },
-      {
-        "package": "swift-custom-dump",
-        "repositoryURL": "https://github.com/pointfreeco/swift-custom-dump",
-        "state": {
-          "branch": null,
-          "revision": "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
-          "version": "1.3.3"
-        }
-      },
-      {
-        "package": "swift-identified-collections",
-        "repositoryURL": "https://github.com/pointfreeco/swift-identified-collections",
-        "state": {
-          "branch": null,
-          "revision": "2f5ab6e091dd032b63dacbda052405756010dc3b",
-          "version": "1.1.0"
-        }
-      },
-      {
-        "package": "swift-syntax",
-        "repositoryURL": "https://github.com/swiftlang/swift-syntax",
-        "state": {
-          "branch": null,
-          "revision": "06b5cdc432e93b60e3bdf53aff2857c6b312991a",
-          "version": "600.0.0-prerelease-2024-07-30"
-        }
-      },
-      {
-        "package": "swiftui-navigation",
-        "repositoryURL": "https://github.com/pointfreeco/swiftui-navigation",
-        "state": {
-          "branch": null,
-          "revision": "fc91d591ebba1f90d65028ccb65c861e5979e898",
-          "version": "1.5.4"
-        }
-      },
-      {
-        "package": "xctest-dynamic-overlay",
-        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
-        "state": {
-          "branch": null,
-          "revision": "357ca1e5dd31f613a1d43320870ebc219386a495",
-          "version": "1.2.2"
-        }
+  "originHash" : "867e2da79f1f4ec1153d93bc5460ddae06a3bfd643fc7e516bebad50ebcc1489",
+  "pins" : [
+    {
+      "identity" : "anycodable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Flight-School/AnyCodable",
+      "state" : {
+        "revision" : "862808b2070cd908cb04f9aafe7de83d35f81b05",
+        "version" : "0.6.7"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "powersync-kotlin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/powersync-ja/powersync-kotlin",
+      "state" : {
+        "revision" : "43198bfc4519563e05052fbab5becb3e18960186",
+        "version" : "1.0.0-BETA1.0"
+      }
+    },
+    {
+      "identity" : "supabase-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/supabase-community/supabase-swift.git",
+      "state" : {
+        "revision" : "b0059a3f30a6a3a7d3b96f786542234a5d1a7835",
+        "version" : "2.18.0"
+      }
+    },
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "642e6aab8e03e5f992d9c83e38c5be98cfad5078",
+        "version" : "1.5.5"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "9bf03ff58ce34478e66aaee630e491823326fd06",
+        "version" : "1.1.3"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "bb5059bde9022d69ac516803f4f227d8ac967f71",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "9f95b4d033a4edd3814b48608db3f2ca90c7218b",
+        "version" : "3.7.0"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
+      }
+    },
+    {
+      "identity" : "swift-identified-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-identified-collections",
+      "state" : {
+        "revision" : "2f5ab6e091dd032b63dacbda052405756010dc3b",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "515f79b522918f83483068d99c68daeb5116342d",
+        "version" : "600.0.0-prerelease-2024-09-04"
+      }
+    },
+    {
+      "identity" : "swiftui-navigation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swiftui-navigation",
+      "state" : {
+        "revision" : "e628806aeaa9efe25c1abcd97931a7c498fab281",
+        "version" : "1.5.5"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "96beb108a57f24c8476ae1f309239270772b2940",
+        "version" : "1.2.5"
+      }
+    }
+  ],
+  "version" : 3
 }

--- a/PowerSyncExample/PowerSync/PowerSync.swift
+++ b/PowerSyncExample/PowerSync/PowerSync.swift
@@ -38,11 +38,11 @@ class PowerSync {
     }
 
     func writeTransaction(_ queryHandle: @escaping () async throws -> Any) async throws -> Any? {
-        try await db.writeTransaction(body: SuspendTaskWrapper(queryHandle))
+        try await db.writeTransaction(callback: SuspendTaskWrapper(queryHandle))
     }
 
     func readTransaction(_ queryHandle: @escaping () async throws -> Any) async throws -> Any? {
-        try await db.readTransaction(body: SuspendTaskWrapper(queryHandle))
+        try await db.readTransaction(callback: SuspendTaskWrapper(queryHandle))
     }
 
     func watchLists(_ cb: @escaping (_ lists: [ListContent]) -> Void ) async {
@@ -70,7 +70,7 @@ class PowerSync {
     }
 
     func deleteList(id: String) async throws {
-        try await db.writeTransaction(body: SuspendTaskWrapper {
+        try await db.writeTransaction(callback: SuspendTaskWrapper {
             try await self.db.execute(
                 sql: "DELETE FROM \(LISTS_TABLE) WHERE id = ?",
                 parameters: [id]
@@ -128,7 +128,7 @@ class PowerSync {
     }
 
     func deleteTodo(id: String) async throws {
-        try await db.writeTransaction(body: SuspendTaskWrapper {
+        try await db.writeTransaction(callback: SuspendTaskWrapper {
             try await self.db.execute(
                 sql: "DELETE FROM \(TODOS_TABLE) WHERE id = ?",
                 parameters: [id]

--- a/PowerSyncExample/PowerSync/Schema.swift
+++ b/PowerSyncExample/PowerSync/Schema.swift
@@ -15,7 +15,7 @@ let lists = Table(
     indexes: [],
     localOnly: false,
     insertOnly: false,
-    _viewNameOverride: LISTS_TABLE
+    viewNameOverride: LISTS_TABLE
 )
 
 let todos = Table(
@@ -41,7 +41,7 @@ let todos = Table(
     ],
     localOnly: false,
     insertOnly: false,
-    _viewNameOverride: TODOS_TABLE
+    viewNameOverride: TODOS_TABLE
 )
 
 let AppSchema = Schema(tables: [lists, todos])

--- a/README.md
+++ b/README.md
@@ -63,32 +63,6 @@ You can obtain your PowerSync Instance URL by following these steps:
 - Click "Edit instance"
 - Click on "Instance URL" to copy the value
 
-## Configure Xcode access to SDK binary
-
-The below steps are required by [KMMBridge](https://touchlab.co/quick-start-with-kmmbridge-1-hour-tutorial#configure-xcode-clients):
-
-### Create GitHub Personal Access Token (PAT)
-
-In your GitHub:
-
-1. Under your user account, navigate to “Settings” -> “Developer Settings” -> “Personal access tokens” -> “Tokens (classic)”
-2. Click “Generate new token” and select “Generate new token (classic)”
-3. Given the token a name e.g. PowerSync XCode
-4. Set the expiration date to “No expiration”, since we won’t be giving this token any sensitive privileges
-5. Under “Select scopes”, enable the “read:packages” checkbox (don’t need “write:packages”)
-6. Click Generate Token
-7. Copy the value for the next step
-
-### Create .netrc file
-
-1. Create a file `~/.netrc` with the following contents:
-
-```
-machine maven.pkg.github.com
-  login [your GitHub username]
-  password [your PAT from the previous step]
-```
-
 ### Finish XCode configuration
 
 1. Clear Swift caches
@@ -102,6 +76,8 @@ rm -rf ~/Library/org.swift.swiftpm
 3. In Xcode:
 - Reset Packages: File -> Packages -> Reset Package Caches
 - Clean Build: Product -> Clean Build Folder.
+
+4. Enable CasePathMacros. We are using SwiftUI Navigation for the demo which requires this.
 
 ## Run project
 


### PR DESCRIPTION
## Description
Updated to latest kmmbridge version BETA1.0, which required some argument naming changes. This allows us to move to open alpha for the Swift package.

It also appears Supabase released an update that requires us to have an encodable type for opData. This required the use of the `AnyCodable` package so that we can get the typing right for opData which is dynamic.

Lastly, I removed references in the doc from netrc setup and added a note about enabling `CasePathMacro`.
